### PR TITLE
docker_pi_group_users fails with usermod if run without become

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,5 +1,6 @@
 ---
 - name: Add docker_pi_group_users to the docker group
+  become: yes
   user:
     name: "{{ item }}"
     groups: docker


### PR DESCRIPTION
I tried to run this to my very empty rasbian / rasberry 2. Everything works but I run all using user pi

my inventory was
[all:vars]
ansible_ssh_user=pi
ansible_ssh_pass=raspberry
ansible_connection=ssh 
[boxes]
192.168.28.45
`[all:vars]
ansible_ssh_user=pi
ansible_ssh_pass=raspberry
ansible_connection=ssh 
[boxes]
192.168.x.x`
my run command was...
` ansible-playbook -i hosts  -v jenkins-pipeline.yml`
and my playbook was minimal but I added user pi to main.yml 

I failed to add user pi to group docker with command without explicit become-command.

